### PR TITLE
fix: Sorting of searched mods through download mods Fixes #3792

### DIFF
--- a/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
+++ b/patches/tModLoader/Terraria/Social/Steam/WorkshopHelper.TML.cs
@@ -359,7 +359,7 @@ public partial class WorkshopHelper
 							continue;
 						}
 
-						foreach (var item in await Task.Run(ProcessPageResult))
+						foreach (var item in SortItemsResults(await Task.Run(ProcessPageResult), queryParameters))
 							yield return item;
 					}
 					finally {
@@ -368,6 +368,19 @@ public partial class WorkshopHelper
 
 					currentPageAttempts = 0;
 				} while (++currentPage <= numberPages);
+			}
+
+
+			private IEnumerable<ModDownloadItem> SortItemsResults(IEnumerable<ModDownloadItem> items, QueryParameters queryParameters)
+			{
+				if (!string.IsNullOrEmpty(queryParameters.searchGeneric) || !string.IsNullOrEmpty(queryParameters.searchAuthor))
+					return queryParameters.sortingParamater switch {
+						ModBrowserSortMode.DownloadsDescending => items.OrderByDescending(i => i.Downloads),
+						ModBrowserSortMode.Hot => items.OrderBy(i => i.Hot),
+						ModBrowserSortMode.RecentlyUpdated => items.OrderByDescending(i => i.TimeStamp),
+						_ => items,
+					};
+				return items;
 			}
 
 			private IEnumerable<ModDownloadItem> ProcessPageResult()


### PR DESCRIPTION
Added additional sorting when text search is used for the workshop query